### PR TITLE
Add echo logging and integrate disk-cleanup.sh

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag renedis/rsync-backup:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-LABEL maintainer="Wei Kin Huang"
+LABEL maintainer="renedis"
 
 RUN set -x \
     && apk add --no-cache \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,5 @@ services:
     volumes:
       - /SOURCE-FOLDER-TO-SYNC:/source:ro
       - /DESTINATION-FOLDER-TO-SYNC:/target
-    command: bash disk-backup.sh
     image: renedis/rsync-backup:latest
 ```

--- a/README.md
+++ b/README.md
@@ -1,161 +1,38 @@
 Container for daily backups based on rsync
 ---
 
-Backup script using incremental rsync and hardlinks.
-
----
-
-[![Docker Image](https://img.shields.io/docker/pulls/weikinhuang/rsync-backup.svg)](https://hub.docker.com/r/weikinhuang/rsync-backup/)
-
----
-## Scripts
-
-### `disk-backup.sh`
-
+## Script
+### `disk-backup`
 This script creates a backup using rsync of a local or a remote directory.
+Environment variables are used to configure the script. When MAX_AGE variable is set it calls a second script on completion.
+All log output of rsync and scripts are sent to docker if --log-file=/dev/stdout is set.
 
-Environment variables are used to configure the script.
+I run a local crontab to run the container daily.
 
+## Variables
 ```bash
 TARGET_DIR=         # path where the backups are stored
 SOURCE_DIR=         # local or remote path to backup eg. /home/foobar OR foobar@some.host.com:/home/foobar
 SSH_OPTIONS=        # ssh options to pass into rsync eg. -o UserKnownHostsFile=/dev/null
 RSYNC_OPTIONS=      # additional rsync options
+MAX_AGE=            # oldest backup to keep in days, anything older will be deleted. If not set, it's ignored.
 ```
-
-### `disk-cleanup.sh`
-
-This script cleans up old backups older than `MAX_AGE`
-
-Environment variables are used to configure the script.
-
+## Usage Scenario
+#### Docker compose
 ```bash
-TARGET_DIR=         # path where the backups are stored
-MAX_AGE=            # oldest backup to keep in days, anything older will be deleted
-```
-
-## Usage Scenarios
-
-#### One-off
-
-```bash
-docker run --rm \
-    --env "SOURCE_DIR=/source" \
-    --env "TARGET_DIR=/target" \
-    --volume "/apps:/source:ro" \
-    --volume "/backups/apps:/target" \
-    weikinhuang/rsync-backup:latest
-```
-
-#### Crontab
-
-`crontab`:
-```
-30 9 * * * /usr/bin/docker run --rm --env "SOURCE_DIR=/source" --env "TARGET_DIR=/target" --volume "/apps:/source:ro" --volume "/backups/apps:/target" weikinhuang/rsync-backup:latest
-```
-
-#### Systemd Timer
-
-`rsync-backup.apps.timer`:
-```ini
-[Unit]
-Description=Timer for rsync backup of "/apps" directory
-Requires=docker.service
-
-[Timer]
-OnCalendar=*-*-* 09:30:00
-
-[Install]
-WantedBy=timers.target
-```
-
-`rsync-backup.apps.service`:
-```ini
-[Unit]
-Description=rsync backup of "/apps" directory
-Requires=docker.service
-
-[Service]
-TimeoutStartSec=0
-Type=oneshot
-
-Environment=DOCKER_IMAGE=weikinhuang/rsync-backup:latest
-Environment=CONTAINER_NAME=%n
-
-Environment="SOURCE_DIR=/apps"
-Environment="TARGET_DIR=/backups/apps"
-
-ExecStartPre=-/usr/bin/docker pull "${DOCKER_IMAGE}"
-ExecStart=/usr/bin/docker run --rm \
-    --name "${CONTAINER_NAME}" \
-    --env "SOURCE_DIR=/source" \
-    --env "TARGET_DIR=/target" \
-    --volume "${SOURCE_DIR}:/source:ro" \
-    --volume "${TARGET_DIR}:/target" \
-    "${DOCKER_IMAGE}"
-```
-
-#### Kubernetes
-
-`backup.yaml`:
-```yaml
-kind: CronJob
-apiVersion: batch/v2alpha1  # batch/v1beta1 for k8s >= 1.8
-metadata:
-  name: backup-apps
-  namespace: default
-spec:
-  schedule: "30 9 * * *"
-  concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 5
-  failedJobsHistoryLimit: 5
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          containers:
-          - name: rsync-backup
-            image: weikinhuang/rsync-backup:latest
-            imagePullPolicy: Always
-            env:
-              - name: SOURCE_DIR
-                value: "/source"
-              - name: TARGET_DIR
-                value: "/target"
-            volumeMounts:
-              - name: source
-                mountPath: /source
-                readOnly: true
-              - name: target
-                mountPath: /target
-          # restartPolicy: OnFailure # retry until success
-          volumes:
-            - name: source
-              hostPath:
-                path: /apps
-            - name: target
-              hostPath:
-                path: /backups/apps
-```
-
-## Development
-
-Build container with:
-
-```bash
-docker build -t rsync-backup .
-```
-
-Run container with:
-
-```bash
-docker run -it --rm \
-    -v $(pwd)/container/usr/local/bin/disk-backup.sh:/usr/local/bin/disk-backup.sh:ro \
-    -v $(pwd)/container/usr/local/bin/disk-backup-cleanup.sh:/usr/local/bin/disk-backup-cleanup.sh:ro \
-    rsync-backup bash
-```
-
-Testing scripts:
-```bash
-env SOURCE_DIR=/etc/profile.d TARGET_DIR=/tmp disk-backup.sh
+version: "3"
+services:
+  rsync-backup:
+    container_name: rsync-backup
+    environment:
+      - TZ=Europe/Amsterdam
+      - SOURCE_DIR=/source
+      - TARGET_DIR=/target
+      - MAX_AGE=30
+      - RSYNC_OPTIONS=-avh --perms --chmod=u+rwx --stats --progress --log-file=/dev/stdout
+    volumes:
+      - /SOURCE-FOLDER-TO-SYNC:/source:ro
+      - /DESTINATION-FOLDER-TO-SYNC:/target
+    command: bash disk-backup.sh
+    image: renedis/rsync-backup:latest
 ```

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ services:
     volumes:
       - /SOURCE-FOLDER-TO-SYNC:/source:ro
       - /DESTINATION-FOLDER-TO-SYNC:/target
-    image: renedis/rsync-backup:latest
+    image: weikinhuang/rync-backup:latest
 ```

--- a/container/usr/local/bin/disk-backup.sh
+++ b/container/usr/local/bin/disk-backup.sh
@@ -28,7 +28,7 @@ if [[ "${SOURCE_DIR}" == /* ]] && [[ ! -d "${SOURCE_DIR}" ]]; then
   exit 1
 fi
 
-TIMESTAMP="$(date +%Y-%m-%d.%H-%M-%S)"
+TIMESTAMP="$(date +%H.%M_%d-%m-%Y)"
 TARGET_DIR_PATH="${TARGET_DIR/%\//}/daily"
 COMPLETE_TARGET_DIR="${TARGET_DIR_PATH}.backup_${TIMESTAMP}"
 INCOMPLETE_TARGET_DIR="${TARGET_DIR_PATH}.incomplete"

--- a/container/usr/local/bin/disk-backup.sh
+++ b/container/usr/local/bin/disk-backup.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -euo pipefail
-IFS=$'\n\t'
 
 if [[ -n ${VERBOSE:-} ]]; then
-    set -x
+  set -x
 fi
 
+# run max age if requested
+MAX_AGE="${MAX_AGE:-}"
 TARGET_DIR="${TARGET_DIR:-}"
 SOURCE_DIR="${SOURCE_DIR:-}"
 if [[ -z "${TARGET_DIR}" ]]; then
@@ -18,13 +19,13 @@ if [[ -z "${SOURCE_DIR}" ]]; then
 fi
 
 if [[ ! -d "${TARGET_DIR}" ]]; then
-    echo "Destination directory not found"
-    exit 1
+  echo "Destination directory not found"
+  exit 1
 fi
 
 if [[ "${SOURCE_DIR}" == /* ]] && [[ ! -d "${SOURCE_DIR}" ]]; then
-    echo "Source directory not found"
-    exit 1
+  echo "Source directory not found"
+  exit 1
 fi
 
 TIMESTAMP="$(date +%Y-%m-%d.%H-%M-%S)"
@@ -36,43 +37,76 @@ CURRENT_TARGET_DIR="${TARGET_DIR_PATH}.current"
 # this is not targeted as a reusable container
 SSH_KEYFILE=""
 SSH_KEYFILE_TMP=
+# shellcheck disable=SC2174
+mkdir -p --mode=0700 /tmp/ssh-temp
 if [[ -r /mnt/id_rsa ]] && [[ -r /mnt/id_rsa.pub ]]; then
-    SSH_KEYFILE_TMP="$(mktemp /tmp/ssh.id_rsa.XXXXXX)"
-    cat /mnt/id_rsa > ${SSH_KEYFILE_TMP}
-    cat /mnt/id_rsa.pub > ${SSH_KEYFILE_TMP}.pub
-    SSH_KEYFILE="-i ${SSH_KEYFILE_TMP}"
+  SSH_KEYFILE_TMP="$(mktemp /tmp/ssh-temp/ssh.id_rsa.XXXXXX)"
+  cat /mnt/id_rsa >"${SSH_KEYFILE_TMP}"
+  cat /mnt/id_rsa.pub >"${SSH_KEYFILE_TMP}.pub"
+  chmod 600 "${SSH_KEYFILE_TMP}" "${SSH_KEYFILE_TMP}.pub"
+  SSH_KEYFILE="-i ${SSH_KEYFILE_TMP}"
+fi
+if [[ -n "${SSH_PRIVATE_KEY:-}" ]]; then
+  SSH_KEYFILE_TMP="$(mktemp /tmp/ssh-temp/ssh.id_rsa.XXXXXX)"
+  set +x
+  echo "${SSH_PRIVATE_KEY}" >"${SSH_KEYFILE_TMP}"
+  if [[ -n ${VERBOSE:-} ]]; then
+    set -x
+  fi
+  chmod 600 "${SSH_KEYFILE_TMP}"
+  SSH_KEYFILE="-i ${SSH_KEYFILE_TMP}"
+
+  if [[ -n "${SSH_PUBLIC_KEY:-}" ]]; then
+    set +x
+    echo "${SSH_PUBLIC_KEY}" >"${SSH_KEYFILE_TMP}.pub"
+    if [[ -n ${VERBOSE:-} ]]; then
+      set -x
+    fi
+    chmod 600 "${SSH_KEYFILE_TMP}.pub"
+  fi
 fi
 
 # ssh verbosity level
 SSH_LOGGING_LEVEL="-q"
 if [[ -n ${VERBOSE:-} ]]; then
-    SSH_LOGGING_LEVEL="-v"
+  SSH_LOGGING_LEVEL="-v"
+fi
+
+# setup initial structure
+if [[ ! -L "${CURRENT_TARGET_DIR}" ]]; then
+  mkdir "${CURRENT_TARGET_DIR}.tmp"
+  (cd "${TARGET_DIR}" && ln -s "$(basename "${CURRENT_TARGET_DIR}").tmp" "${CURRENT_TARGET_DIR}")
 fi
 
 # Clean up stray files
-function cleanup {
-    if [[ -e "${SSH_KEYFILE_TMP}" ]]; then
-        rm -f "${SSH_KEYFILE_TMP}" "${SSH_KEYFILE_TMP}.pub"
-    fi
+function cleanup() {
+  if [[ -e "${SSH_KEYFILE_TMP}" ]]; then
+    rm -f "${SSH_KEYFILE_TMP}" "${SSH_KEYFILE_TMP}.pub"
+  fi
+  if [[ -d "${CURRENT_TARGET_DIR}.tmp" ]]; then
+    rm -rf "${CURRENT_TARGET_DIR}.tmp"
+  fi
 }
 trap cleanup EXIT
 
+# shellcheck disable=SC2191,SC2206
 RSYNC_ARGS=(
-    --archive
-    --one-file-system
-    --hard-links
-    --human-readable
-    --inplace
-    --numeric-ids
-    --delete
-    --ignore-errors
-    --verbose
-    -F # --filter='dir-merge /.rsync-filter' repeated: --filter='- .rsync-filter'
-    --rsh="ssh -p ${SSH_PORT:-22} ${SSH_LOGGING_LEVEL} -o ConnectTimeout=${SSH_CONNECT_TIMEOUT:-5} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${SSH_KEYFILE} ${SSH_OPTIONS:-}"
-    --link-dest="${CURRENT_TARGET_DIR}/"
-    ${RSYNC_OPTIONS:-}
-    "${SOURCE_DIR/%\//}/"
-    "${INCOMPLETE_TARGET_DIR}/"
+  -avh
+  --archive
+  --one-file-system
+  --hard-links
+  --human-readable
+  --inplace
+  --numeric-ids
+  --delete
+  --ignore-errors
+  --verbose
+  -F # --filter='dir-merge /.rsync-filter' repeated: --filter='- .rsync-filter'
+  --rsh="ssh -p ${SSH_PORT:-22} ${SSH_LOGGING_LEVEL} -o ConnectTimeout=${SSH_CONNECT_TIMEOUT:-5} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${SSH_KEYFILE} ${SSH_OPTIONS:-}"
+  --link-dest="${CURRENT_TARGET_DIR}/"
+  ${RSYNC_OPTIONS:-}
+  "${SOURCE_DIR/%\//}/"
+  "${INCOMPLETE_TARGET_DIR}/"
 )
 
 # 1. Copy over all files
@@ -81,7 +115,21 @@ RSYNC_ARGS=(
 # 4. make a new reference to the latest backup
 # 5. make sure this folder's last modified time is now!
 rsync "${RSYNC_ARGS[@]}" \
-    && mv "${INCOMPLETE_TARGET_DIR}" "${COMPLETE_TARGET_DIR}" \
-    && rm -f "${CURRENT_TARGET_DIR}" \
-    && (cd "${TARGET_DIR}" && ln -s "$(basename "${COMPLETE_TARGET_DIR}")" "${CURRENT_TARGET_DIR}" ) \
-    && touch "${COMPLETE_TARGET_DIR}"
+  && mv "${INCOMPLETE_TARGET_DIR}" "${COMPLETE_TARGET_DIR}" \
+  && rm -f "${CURRENT_TARGET_DIR}" \
+  && (cd "${TARGET_DIR}" && ln -s "$(basename "${COMPLETE_TARGET_DIR}")" "${CURRENT_TARGET_DIR}") \
+  && touch "${COMPLETE_TARGET_DIR}"
+
+# only run the dedupe on success
+RSYNC_EXIT_CODE=$?
+
+# run deduplication if requested
+if [[ ${RSYNC_EXIT_CODE} -eq 0 ]] && [[ -n ${DEDUPLICATE:-} ]]; then
+  disk-dedupe.sh "${TARGET_DIR/%\//}" "${COMPLETE_TARGET_DIR}"
+fi
+
+# run max age if requested
+if [[ ${RSYNC_EXIT_CODE} -eq 0 ]] && [[ ${MAX_AGE} ]]; then
+  echo "Backup completed. Starting retention clean up of $MAX_AGE days."
+  disk-cleanup.sh
+fi

--- a/container/usr/local/bin/disk-backup.sh
+++ b/container/usr/local/bin/disk-backup.sh
@@ -101,6 +101,8 @@ RSYNC_ARGS=(
   --delete
   --ignore-errors
   --verbose
+  --stats
+  --progress
   -F # --filter='dir-merge /.rsync-filter' repeated: --filter='- .rsync-filter'
   --rsh="ssh -p ${SSH_PORT:-22} ${SSH_LOGGING_LEVEL} -o ConnectTimeout=${SSH_CONNECT_TIMEOUT:-5} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${SSH_KEYFILE} ${SSH_OPTIONS:-}"
   --link-dest="${CURRENT_TARGET_DIR}/"

--- a/container/usr/local/bin/disk-cleanup.sh
+++ b/container/usr/local/bin/disk-cleanup.sh
@@ -1,51 +1,52 @@
 #!/bin/bash
 set -euo pipefail
-IFS=$'\n\t'
 
 if [[ -n ${VERBOSE:-} ]]; then
-    set -x
+  set -x
 fi
 
 TARGET_DIR="${TARGET_DIR:-}"
 MAX_AGE="${MAX_AGE:-180}"
 if [[ -z "${TARGET_DIR}" ]]; then
-    echo "Unknown TARGET_DIR"
-    exit 1
+  echo "Unknown TARGET_DIR"
+  exit 1
 fi
 
 if [[ ! -d "${TARGET_DIR}" ]]; then
-    echo "Destination directory not found"
-    exit 1
+  echo "Destination directory not found"
+  exit 1
 fi
 
 TARGET_DIR_PATH="${TARGET_DIR/%\//}"
 FIND_ARGS=(
-    "${TARGET_DIR_PATH}"
-    -maxdepth 1
-    -iname 'daily.*'
-    -mtime +${MAX_AGE}
-    -type d
+  "${TARGET_DIR_PATH}"
+  -maxdepth 1
+  -iname 'daily.*'
+  -mtime "+${MAX_AGE}"
+  -type d
 )
 
 # If there's no files to delete, that's ok
-if ! ( find "${FIND_ARGS[@]}" \
-    | grep -v incomplete \
-    | grep -q -v "$(basename "$(readlink "${TARGET_DIR_PATH}/daily.current")")" ); then
-    exit 0
+if ! (find "${FIND_ARGS[@]}" \
+  | grep -v incomplete \
+  | grep -q -v "$(basename "$(readlink "${TARGET_DIR_PATH}/daily.current")")"); then
+  echo "No files to delete older then $MAX_AGE days."
+  exit 0
 fi
 
 # print found files for logging
 find "${FIND_ARGS[@]}" \
-    | grep -v incomplete \
-    | grep -v "$(basename "$(readlink "${TARGET_DIR_PATH}/daily.current")")" \
-    | sort
+  | grep -v incomplete \
+  | grep -v "$(basename "$(readlink "${TARGET_DIR_PATH}/daily.current")")" \
+  | sort
 
 # 1. Find all old backups
 # 2. Exclude the current in progress folder
 # 3. Exclude the current backup
 # 4. remove found backups
 find "${FIND_ARGS[@]}" \
-    | grep -v incomplete \
-    | grep -v "$(basename "$(readlink "${TARGET_DIR_PATH}/daily.current")")" \
-    | sort \
-    | xargs -t -r rm -rf
+  | grep -v incomplete \
+  | grep -v "$(basename "$(readlink "${TARGET_DIR_PATH}/daily.current")")" \
+  | sort \
+  | xargs -t -r rm -rf
+  echo "Files found to delete older then $MAX_AGE days. They are now deleted."


### PR DESCRIPTION
I like your approach very much although the docker image is 7 years old it fits it purpose. I noticed that there was a disk-cleanup.sh en disk-dedupe.sh. I have no use of the dedupe but the cleanup was something I really wanted to automate with one variable. I've also added my own compose setup and use a local crontab that starts the container at specific time e.g. "30 3 * * * docker start rsync-backup"

I've edited the readme to reflect the docker compose, please feel free to ignore that pull request.